### PR TITLE
Allow script to run without http_proxy set

### DIFF
--- a/emulation_configure.bash
+++ b/emulation_configure.bash
@@ -705,7 +705,7 @@ function emit_libvirt_XML() {
 
 function echo_environment() {
 	FAME_FAM=${FAME_FAM:-"NEEDS TO BE SET!"}
-	echo "http_proxy=$http_proxy"
+	echo "http_proxy=${http_proxy:-}"
 	env | grep FAME_ | sort
 }
 


### PR DESCRIPTION
I am running without a proxy but it fails with an error:

    ./emulation_configure.bash: line 708: http_proxy: unbound variable

This patch fixes the issue.